### PR TITLE
Add output in robot frame option

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -206,7 +206,7 @@ bool handleResetService(um7::Comms* sensor,
  * the ROS messages which are output.
  */
 void publishMsgs(um7::Registers& r, ros::NodeHandle* imu_nh, sensor_msgs::Imu& imu_msg,
-    bool tf_ned_to_enu, bool use_magnetic_field_msg)
+    bool tf_ned_to_nwu, bool use_magnetic_field_msg)
 {
   static ros::Publisher imu_pub = imu_nh->advertise<sensor_msgs::Imu>("data", 1, false);
   static ros::Publisher mag_pub;
@@ -225,7 +225,7 @@ void publishMsgs(um7::Registers& r, ros::NodeHandle* imu_nh, sensor_msgs::Imu& i
   {
     // body-fixed frame NED to ENU: (x y z)->(x -y -z) or (w x y z)->(x -y -z w)
     // world frame      NED to ENU: (x y z)->(y  x -z) or (w x y z)->(y  x -z w)
-    if (tf_ned_to_enu)
+    if (tf_ned_to_nwu)
     {
       // world frame
       imu_msg.orientation.w =  -r.quat.get_scaled(0);
@@ -270,7 +270,7 @@ void publishMsgs(um7::Registers& r, ros::NodeHandle* imu_nh, sensor_msgs::Imu& i
       sensor_msgs::MagneticField mag_msg;
       mag_msg.header = imu_msg.header;
 
-      if (tf_ned_to_enu)
+      if (tf_ned_to_nwu)
       {
         mag_msg.magnetic_field.x = r.mag.get_scaled(1);
         mag_msg.magnetic_field.y = r.mag.get_scaled(0);
@@ -290,7 +290,7 @@ void publishMsgs(um7::Registers& r, ros::NodeHandle* imu_nh, sensor_msgs::Imu& i
       geometry_msgs::Vector3Stamped mag_msg;
       mag_msg.header = imu_msg.header;
 
-      if (tf_ned_to_enu)
+      if (tf_ned_to_nwu)
       {
         mag_msg.vector.x = r.mag.get_scaled(1);
         mag_msg.vector.y = r.mag.get_scaled(0);
@@ -313,7 +313,7 @@ void publishMsgs(um7::Registers& r, ros::NodeHandle* imu_nh, sensor_msgs::Imu& i
     geometry_msgs::Vector3Stamped rpy_msg;
     rpy_msg.header = imu_msg.header;
 
-    if (tf_ned_to_enu)
+    if (tf_ned_to_nwu)
     {
       // world frame
       rpy_msg.vector.x =  r.euler.get_scaled(1);
@@ -381,8 +381,8 @@ int main(int argc, char **argv)
   double orientation_z_covar = orientation_z_stdev * orientation_z_stdev;
 
   // Enable converting from NED to ENU by default
-  bool tf_ned_to_enu;
-  private_nh.param<bool>("tf_ned_to_enu", tf_ned_to_enu, true);
+  bool tf_ned_to_nwu;
+  private_nh.param<bool>("tf_ned_to_nwu", tf_ned_to_nwu, true);
 
   // Use MagneticField message rather than Vector3Stamped.
   bool use_magnetic_field_msg;
@@ -432,7 +432,7 @@ int main(int argc, char **argv)
           {
             // Triggered by arrival of final message in group.
             imu_msg.header.stamp = ros::Time::now();
-            publishMsgs(registers, &imu_nh, imu_msg, tf_ned_to_enu, use_magnetic_field_msg);
+            publishMsgs(registers, &imu_nh, imu_msg, tf_ned_to_nwu, use_magnetic_field_msg);
             ros::spinOnce();
           }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -228,8 +228,8 @@ void publishMsgs(um7::Registers& r, ros::NodeHandle* imu_nh, sensor_msgs::Imu& i
     if (tf_ned_to_nwu)
     {
       // world frame
-      imu_msg.orientation.w =  -r.quat.get_scaled(0);
-      imu_msg.orientation.x =  -r.quat.get_scaled(1);
+      imu_msg.orientation.w = -r.quat.get_scaled(0);
+      imu_msg.orientation.x = -r.quat.get_scaled(1);
       imu_msg.orientation.y =  r.quat.get_scaled(2);
       imu_msg.orientation.z =  r.quat.get_scaled(3);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -230,64 +230,64 @@ void publishMsgs(um7::Registers& r, ros::NodeHandle* imu_nh, sensor_msgs::Imu& i
   {
     switch (axes)
     {
-        case ENU:
-        {
-            // body-fixed frame NED to ENU: (x y z)->(x -y -z) or (w x y z)->(x -y -z w)
-            // world frame      NED to ENU: (x y z)->(y  x -z) or (w x y z)->(y  x -z w)
-            // world frame
-            imu_msg.orientation.w =  r.quat.get_scaled(2);
-            imu_msg.orientation.x =  r.quat.get_scaled(1);
-            imu_msg.orientation.y = -r.quat.get_scaled(3);
-            imu_msg.orientation.z =  r.quat.get_scaled(0);
+      case ENU:
+      {
+        // body-fixed frame NED to ENU: (x y z)->(x -y -z) or (w x y z)->(x -y -z w)
+        // world frame      NED to ENU: (x y z)->(y  x -z) or (w x y z)->(y  x -z w)
+        // world frame
+        imu_msg.orientation.w =  r.quat.get_scaled(2);
+        imu_msg.orientation.x =  r.quat.get_scaled(1);
+        imu_msg.orientation.y = -r.quat.get_scaled(3);
+        imu_msg.orientation.z =  r.quat.get_scaled(0);
 
-            // body-fixed frame
-            imu_msg.angular_velocity.x =  r.gyro.get_scaled(0);
-            imu_msg.angular_velocity.y = -r.gyro.get_scaled(1);
-            imu_msg.angular_velocity.z = -r.gyro.get_scaled(2);
+        // body-fixed frame
+        imu_msg.angular_velocity.x =  r.gyro.get_scaled(0);
+        imu_msg.angular_velocity.y = -r.gyro.get_scaled(1);
+        imu_msg.angular_velocity.z = -r.gyro.get_scaled(2);
 
-            // body-fixed frame
-            imu_msg.linear_acceleration.x =  r.accel.get_scaled(0);
-            imu_msg.linear_acceleration.y = -r.accel.get_scaled(1);
-            imu_msg.linear_acceleration.z = -r.accel.get_scaled(2);
-            break;
-        }
-        case ROBOT_FRAME:
-        {
-            // body-fixed frame
-            imu_msg.orientation.w = -r.quat.get_scaled(0);
-            imu_msg.orientation.x = -r.quat.get_scaled(1);
-            imu_msg.orientation.y =  r.quat.get_scaled(2);
-            imu_msg.orientation.z =  r.quat.get_scaled(3);
+        // body-fixed frame
+        imu_msg.linear_acceleration.x =  r.accel.get_scaled(0);
+        imu_msg.linear_acceleration.y = -r.accel.get_scaled(1);
+        imu_msg.linear_acceleration.z = -r.accel.get_scaled(2);
+        break;
+      }
+      case ROBOT_FRAME:
+      {
+        // body-fixed frame
+        imu_msg.orientation.w = -r.quat.get_scaled(0);
+        imu_msg.orientation.x = -r.quat.get_scaled(1);
+        imu_msg.orientation.y =  r.quat.get_scaled(2);
+        imu_msg.orientation.z =  r.quat.get_scaled(3);
 
-            // body-fixed frame
-            imu_msg.angular_velocity.x =  r.gyro.get_scaled(0);
-            imu_msg.angular_velocity.y = -r.gyro.get_scaled(1);
-            imu_msg.angular_velocity.z = -r.gyro.get_scaled(2);
+        // body-fixed frame
+        imu_msg.angular_velocity.x =  r.gyro.get_scaled(0);
+        imu_msg.angular_velocity.y = -r.gyro.get_scaled(1);
+        imu_msg.angular_velocity.z = -r.gyro.get_scaled(2);
 
-            // body-fixed frame
-            imu_msg.linear_acceleration.x =  r.accel.get_scaled(0);
-            imu_msg.linear_acceleration.y = -r.accel.get_scaled(1);
-            imu_msg.linear_acceleration.z = -r.accel.get_scaled(2);
-            break;
-        }
-        case DEFAULT:
-        {
-            imu_msg.orientation.w = r.quat.get_scaled(0);
-            imu_msg.orientation.x = r.quat.get_scaled(1);
-            imu_msg.orientation.y = r.quat.get_scaled(2);
-            imu_msg.orientation.z = r.quat.get_scaled(3);
+        // body-fixed frame
+        imu_msg.linear_acceleration.x =  r.accel.get_scaled(0);
+        imu_msg.linear_acceleration.y = -r.accel.get_scaled(1);
+        imu_msg.linear_acceleration.z = -r.accel.get_scaled(2);
+        break;
+      }
+      case DEFAULT:
+      {
+        imu_msg.orientation.w = r.quat.get_scaled(0);
+        imu_msg.orientation.x = r.quat.get_scaled(1);
+        imu_msg.orientation.y = r.quat.get_scaled(2);
+        imu_msg.orientation.z = r.quat.get_scaled(3);
 
-            imu_msg.angular_velocity.x = r.gyro.get_scaled(0);
-            imu_msg.angular_velocity.y = r.gyro.get_scaled(1);
-            imu_msg.angular_velocity.z = r.gyro.get_scaled(2);
+        imu_msg.angular_velocity.x = r.gyro.get_scaled(0);
+        imu_msg.angular_velocity.y = r.gyro.get_scaled(1);
+        imu_msg.angular_velocity.z = r.gyro.get_scaled(2);
 
-            imu_msg.linear_acceleration.x = r.accel.get_scaled(0);
-            imu_msg.linear_acceleration.y = r.accel.get_scaled(1);
-            imu_msg.linear_acceleration.z = r.accel.get_scaled(2);
-            break;
-        }
-        default:
-            ROS_ERROR("OuputAxes enum value invalid");
+        imu_msg.linear_acceleration.x = r.accel.get_scaled(0);
+        imu_msg.linear_acceleration.y = r.accel.get_scaled(1);
+        imu_msg.linear_acceleration.z = r.accel.get_scaled(2);
+        break;
+      }
+      default:
+        ROS_ERROR("OuputAxes enum value invalid");
     }
 
     imu_pub.publish(imu_msg);
@@ -303,30 +303,30 @@ void publishMsgs(um7::Registers& r, ros::NodeHandle* imu_nh, sensor_msgs::Imu& i
 
       switch (axes)
       {
-          case ENU:
-          {
-              mag_msg.magnetic_field.x = r.mag.get_scaled(1);
-              mag_msg.magnetic_field.y = r.mag.get_scaled(0);
-              mag_msg.magnetic_field.z = -r.mag.get_scaled(2);
-              break;
-          }
-          case ROBOT_FRAME:
-          {
-              // body-fixed frame
-              mag_msg.magnetic_field.x =  r.mag.get_scaled(0);
-              mag_msg.magnetic_field.y = -r.mag.get_scaled(1);
-              mag_msg.magnetic_field.z = -r.mag.get_scaled(2);
-              break;
-          }
-          case DEFAULT:
-          {
-              mag_msg.magnetic_field.x = r.mag.get_scaled(0);
-              mag_msg.magnetic_field.y = r.mag.get_scaled(1);
-              mag_msg.magnetic_field.z = r.mag.get_scaled(2);
-              break;
-          }
-          default:
-              ROS_ERROR("OuputAxes enum value invalid");
+        case ENU:
+        {
+          mag_msg.magnetic_field.x = r.mag.get_scaled(1);
+          mag_msg.magnetic_field.y = r.mag.get_scaled(0);
+          mag_msg.magnetic_field.z = -r.mag.get_scaled(2);
+          break;
+        }
+        case ROBOT_FRAME:
+        {
+          // body-fixed frame
+          mag_msg.magnetic_field.x =  r.mag.get_scaled(0);
+          mag_msg.magnetic_field.y = -r.mag.get_scaled(1);
+          mag_msg.magnetic_field.z = -r.mag.get_scaled(2);
+          break;
+        }
+        case DEFAULT:
+        {
+          mag_msg.magnetic_field.x = r.mag.get_scaled(0);
+          mag_msg.magnetic_field.y = r.mag.get_scaled(1);
+          mag_msg.magnetic_field.z = r.mag.get_scaled(2);
+          break;
+        }
+        default:
+          ROS_ERROR("OuputAxes enum value invalid");
       }
 
       mag_pub.publish(mag_msg);
@@ -338,30 +338,30 @@ void publishMsgs(um7::Registers& r, ros::NodeHandle* imu_nh, sensor_msgs::Imu& i
 
       switch (axes)
       {
-          case ENU:
-          {
-              mag_msg.vector.x = r.mag.get_scaled(1);
-              mag_msg.vector.y = r.mag.get_scaled(0);
-              mag_msg.vector.z = -r.mag.get_scaled(2);
-              break;
-          }
-          case ROBOT_FRAME:
-          {
-              // body-fixed frame
-              mag_msg.vector.x =  r.mag.get_scaled(0);
-              mag_msg.vector.y = -r.mag.get_scaled(1);
-              mag_msg.vector.z = -r.mag.get_scaled(2);
-              break;
-          }
-          case DEFAULT:
-          {
-              mag_msg.vector.x = r.mag.get_scaled(0);
-              mag_msg.vector.y = r.mag.get_scaled(1);
-              mag_msg.vector.z = r.mag.get_scaled(2);
-              break;
-          }
-          default:
-              ROS_ERROR("OuputAxes enum value invalid");
+        case ENU:
+        {
+          mag_msg.vector.x = r.mag.get_scaled(1);
+          mag_msg.vector.y = r.mag.get_scaled(0);
+          mag_msg.vector.z = -r.mag.get_scaled(2);
+          break;
+        }
+        case ROBOT_FRAME:
+        {
+          // body-fixed frame
+          mag_msg.vector.x =  r.mag.get_scaled(0);
+          mag_msg.vector.y = -r.mag.get_scaled(1);
+          mag_msg.vector.z = -r.mag.get_scaled(2);
+          break;
+        }
+        case DEFAULT:
+        {
+          mag_msg.vector.x = r.mag.get_scaled(0);
+          mag_msg.vector.y = r.mag.get_scaled(1);
+          mag_msg.vector.z = r.mag.get_scaled(2);
+          break;
+        }
+        default:
+          ROS_ERROR("OuputAxes enum value invalid");
       }
 
       mag_pub.publish(mag_msg);
@@ -376,30 +376,30 @@ void publishMsgs(um7::Registers& r, ros::NodeHandle* imu_nh, sensor_msgs::Imu& i
 
     switch (axes)
     {
-        case ENU:
-        {
-            // world frame
-            rpy_msg.vector.x = r.euler.get_scaled(1);
-            rpy_msg.vector.y = r.euler.get_scaled(0);
-            rpy_msg.vector.z = -r.euler.get_scaled(2);
-            break;
-        }
-        case ROBOT_FRAME:
-        {
-            rpy_msg.vector.x =  r.euler.get_scaled(0);
-            rpy_msg.vector.y = -r.euler.get_scaled(1);
-            rpy_msg.vector.z = -r.euler.get_scaled(2);
-            break;
-        }
-        case DEFAULT:
-        {
-            rpy_msg.vector.x = r.euler.get_scaled(0);
-            rpy_msg.vector.y = r.euler.get_scaled(1);
-            rpy_msg.vector.z = r.euler.get_scaled(2);
-            break;
-        }
-        default:
-            ROS_ERROR("OuputAxes enum value invalid");
+      case ENU:
+      {
+        // world frame
+        rpy_msg.vector.x = r.euler.get_scaled(1);
+        rpy_msg.vector.y = r.euler.get_scaled(0);
+        rpy_msg.vector.z = -r.euler.get_scaled(2);
+        break;
+      }
+      case ROBOT_FRAME:
+      {
+        rpy_msg.vector.x =  r.euler.get_scaled(0);
+        rpy_msg.vector.y = -r.euler.get_scaled(1);
+        rpy_msg.vector.z = -r.euler.get_scaled(2);
+        break;
+      }
+      case DEFAULT:
+      {
+        rpy_msg.vector.x = r.euler.get_scaled(0);
+        rpy_msg.vector.y = r.euler.get_scaled(1);
+        rpy_msg.vector.z = r.euler.get_scaled(2);
+        break;
+      }
+      default:
+        ROS_ERROR("OuputAxes enum value invalid");
     }
 
     rpy_pub.publish(rpy_msg);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,7 +51,8 @@ const char VERSION[10] = "0.0.2";   // um7_driver version
 // us to publish everything we have.
 const uint8_t TRIGGER_PACKET = DREG_EULER_PHI_THETA;
 
-enum OutputAxes {
+enum OutputAxes
+{
     DEFAULT, ENU, ROBOT_FRAME
 };
 
@@ -227,7 +228,8 @@ void publishMsgs(um7::Registers& r, ros::NodeHandle* imu_nh, sensor_msgs::Imu& i
 
   if (imu_pub.getNumSubscribers() > 0)
   {
-    switch(axes) {
+    switch (axes)
+    {
         case ENU:
         {
             // body-fixed frame NED to ENU: (x y z)->(x -y -z) or (w x y z)->(x -y -z w)
@@ -299,21 +301,25 @@ void publishMsgs(um7::Registers& r, ros::NodeHandle* imu_nh, sensor_msgs::Imu& i
       sensor_msgs::MagneticField mag_msg;
       mag_msg.header = imu_msg.header;
 
-      switch(axes) {
-          case ENU: {
+      switch (axes)
+      {
+          case ENU:
+          {
               mag_msg.magnetic_field.x = r.mag.get_scaled(1);
               mag_msg.magnetic_field.y = r.mag.get_scaled(0);
               mag_msg.magnetic_field.z = -r.mag.get_scaled(2);
               break;
           }
-          case ROBOT_FRAME: {
+          case ROBOT_FRAME:
+          {
               // body-fixed frame
               mag_msg.magnetic_field.x =  r.mag.get_scaled(0);
               mag_msg.magnetic_field.y = -r.mag.get_scaled(1);
               mag_msg.magnetic_field.z = -r.mag.get_scaled(2);
               break;
           }
-          case DEFAULT: {
+          case DEFAULT:
+          {
               mag_msg.magnetic_field.x = r.mag.get_scaled(0);
               mag_msg.magnetic_field.y = r.mag.get_scaled(1);
               mag_msg.magnetic_field.z = r.mag.get_scaled(2);
@@ -330,29 +336,33 @@ void publishMsgs(um7::Registers& r, ros::NodeHandle* imu_nh, sensor_msgs::Imu& i
       geometry_msgs::Vector3Stamped mag_msg;
       mag_msg.header = imu_msg.header;
 
-        switch(axes) {
-            case ENU: {
-                mag_msg.vector.x = r.mag.get_scaled(1);
-                mag_msg.vector.y = r.mag.get_scaled(0);
-                mag_msg.vector.z = -r.mag.get_scaled(2);
-                break;
-            }
-            case ROBOT_FRAME: {
-                // body-fixed frame
-                mag_msg.vector.x =  r.mag.get_scaled(0);
-                mag_msg.vector.y = -r.mag.get_scaled(1);
-                mag_msg.vector.z = -r.mag.get_scaled(2);
-                break;
-            }
-            case DEFAULT:{
-                mag_msg.vector.x = r.mag.get_scaled(0);
-                mag_msg.vector.y = r.mag.get_scaled(1);
-                mag_msg.vector.z = r.mag.get_scaled(2);
-                break;
-            }
-            default:
-                ROS_ERROR("OuputAxes enum value invalid");
-        }
+      switch (axes)
+      {
+          case ENU:
+          {
+              mag_msg.vector.x = r.mag.get_scaled(1);
+              mag_msg.vector.y = r.mag.get_scaled(0);
+              mag_msg.vector.z = -r.mag.get_scaled(2);
+              break;
+          }
+          case ROBOT_FRAME:
+          {
+              // body-fixed frame
+              mag_msg.vector.x =  r.mag.get_scaled(0);
+              mag_msg.vector.y = -r.mag.get_scaled(1);
+              mag_msg.vector.z = -r.mag.get_scaled(2);
+              break;
+          }
+          case DEFAULT:
+          {
+              mag_msg.vector.x = r.mag.get_scaled(0);
+              mag_msg.vector.y = r.mag.get_scaled(1);
+              mag_msg.vector.z = r.mag.get_scaled(2);
+              break;
+          }
+          default:
+              ROS_ERROR("OuputAxes enum value invalid");
+      }
 
       mag_pub.publish(mag_msg);
     }
@@ -364,21 +374,25 @@ void publishMsgs(um7::Registers& r, ros::NodeHandle* imu_nh, sensor_msgs::Imu& i
     geometry_msgs::Vector3Stamped rpy_msg;
     rpy_msg.header = imu_msg.header;
 
-    switch(axes) {
-        case ENU: {
+    switch (axes)
+    {
+        case ENU:
+        {
             // world frame
             rpy_msg.vector.x = r.euler.get_scaled(1);
             rpy_msg.vector.y = r.euler.get_scaled(0);
             rpy_msg.vector.z = -r.euler.get_scaled(2);
             break;
         }
-        case ROBOT_FRAME: {
+        case ROBOT_FRAME:
+        {
             rpy_msg.vector.x =  r.euler.get_scaled(0);
             rpy_msg.vector.y = -r.euler.get_scaled(1);
             rpy_msg.vector.z = -r.euler.get_scaled(2);
             break;
         }
-        case DEFAULT: {
+        case DEFAULT:
+        {
             rpy_msg.vector.x = r.euler.get_scaled(0);
             rpy_msg.vector.y = r.euler.get_scaled(1);
             rpy_msg.vector.z = r.euler.get_scaled(2);
@@ -450,9 +464,12 @@ int main(int argc, char **argv)
   if (tf_ned_to_enu && tf_ned_to_robot_frame)
   {
       ROS_ERROR("Requested IMU data in two separate frames.");
-  } else if(tf_ned_to_enu) {
+  }
+  else if (tf_ned_to_enu)
+  {
       axes = ENU;
-  } else if(tf_ned_to_robot_frame)
+  }
+  else if (tf_ned_to_robot_frame)
   {
       axes = ROBOT_FRAME;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -228,10 +228,10 @@ void publishMsgs(um7::Registers& r, ros::NodeHandle* imu_nh, sensor_msgs::Imu& i
     if (tf_ned_to_enu)
     {
       // world frame
-      imu_msg.orientation.w =  r.quat.get_scaled(2);
-      imu_msg.orientation.x =  r.quat.get_scaled(1);
-      imu_msg.orientation.y = -r.quat.get_scaled(3);
-      imu_msg.orientation.z =  r.quat.get_scaled(0);
+      imu_msg.orientation.w =  -r.quat.get_scaled(0);
+      imu_msg.orientation.x =  -r.quat.get_scaled(1);
+      imu_msg.orientation.y =  r.quat.get_scaled(2);
+      imu_msg.orientation.z =  r.quat.get_scaled(3);
 
       // body-fixed frame
       imu_msg.angular_velocity.x =  r.gyro.get_scaled(0);


### PR DESCRIPTION
We found that to use Cartographer for mapping/localization, we needed to have the IMU data output not in its default NED frame or in ENU frame, but that we needed it in robot frame (x forward, y left, z up).  This PR adds an option for robot frame output and does not change the NED or ENU output.